### PR TITLE
Update confirmation message for commands with pendingAction to be more general and edit delete message_usage

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -20,7 +20,8 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_CLEAR_CONFIRM =
             "Are you sure you want to clear all entries from the address book?\n"
-                    + "Type 'clear' again to confirm.\n"
+                    + "Type 'clear' again to confirm."
+                    + "(Any leading/trailing spaces will be trimmed)\n"
                     + "Any other command will cancel this pending action.";
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -32,8 +32,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_CONFIRM =
             "Are you sure you want to delete %1$s (%2$s, %3$s)?\n"
                     + "Type '%4$s %5$d' again to confirm. "
-                    + "(Any whitespace will be trimmed, and numbers with leading zeros (e.g., '0%5$d', '00%5$d') "
-                    + "will also confirm the deletion)\n"
+                    + "(Leading/trailing spaces and spaces between the command word and index are ignored, "
+                    + "numbers with leading zeros (e.g., '0%5$d') also confirm the deletion)\n"
                     + "Any other command will cancel this pending deletion.";
 
     private static final Logger logger = LogsCenter.getLogger(DeleteCommand.class);

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -27,7 +27,8 @@ public class DeleteTagCommand extends Command {
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted Tag: %1$s";
     public static final String MESSAGE_DELETE_CONFIRM =
             "Are you sure you want to delete tag %1$s?\n"
-                    + "Type '%2$s %1$s' again to confirm.\n"
+                    + "Type '%2$s %1$s' again to confirm. "
+                    + "(Leading/trailing spaces and spaces between the command word and tag are ignored)\n"
                     + "Any other command will cancel this pending deletion.";
 
     public static final String MESSAGE_TAG_NOT_FOUND = "The tag '%1$s' does not exist in the address book.";

--- a/src/main/java/seedu/address/logic/commands/LogDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogDeleteCommand.java
@@ -32,9 +32,9 @@ public class LogDeleteCommand extends Command {
     public static final String MESSAGE_DELETE_CONFIRM =
             "Are you sure you want to delete log #%2$d from client %1$s?\n"
                     + "Log: %3$s\n"
-                    + "Type '%4$s %5$d %6$d' again to confirm.\n"
-                    + "(Any whitespace will be trimmed, and numbers with leading zeros (e.g., '0%5$d', '00%5$d') "
-                    + "will also confirm the deletion)\n"
+                    + "Type '%4$s %5$d %6$d' again to confirm. "
+                    + "(Leading/trailing spaces and spaces between the command word and indexes are ignored, "
+                    + "numbers with leading zeros (e.g., '0%5$d') also confirm the deletion)\n"
                     + "Any other command will cancel this pending action.";
 
     public static final String MESSAGE_NO_LOGS = "This client has no logs.";


### PR DESCRIPTION
Fixes #190: Updated parameter format in message usage for `delete` to match other commands (`edit`, `view`, `copyaddr`) for consistency.

Fixes #191: Instead of storing the exact command string (which would be trimmed by the current parser implementation anyway), the confirmation message for `delete`, `log-delete`, `clear` and `deletetag` was made more general to clearly indicate:
- Leading/trailing spaces are ignored
- Multiple spaces between command word and arguments are allowed
- Numbers with leading zeros (e.g. `01`, `001`) are accepted