### PR TITLE
Fix find command empty checks on prefixes, and handling of no-tag searching

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -34,8 +34,8 @@ public class FindCommand extends Command {
                     {0}: Finds all clients whose details contain any of the given queries \
                     and displays them as a list with index numbers.
                     Preamble given will result in an error.
-                    Parameters: {1}subName [OPTIONAL_SUBNAMES] {2}subNumber [OPTIONAL_SUBNUMBERS] {3}subEmail \
-                    [OPTIONAL_SUBEMAILS] {4}subAddresses [OPTIONAL_SUBADDRESSES] {5}tags [OPTIONAL_TAGS]
+                    Parameters: find [{1}=SUBNAME]... [{2}SUBNUMBER]... [{3}SUBEMAIL]... [{4}SUBADDRESS]... \
+                    [{5}[SUBTAG]]...
                     Example: {0} {1}david {2}123 {3}d@gmail {4}Woodlands {5}Friend""",
             COMMAND_WORD, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG
     );

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -36,7 +36,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     if (p.equals(PREFIX_TAG)) {
                         return false;
                     }
-                    return argMultimap.getValue(p).map(String::isEmpty).orElse(false);
+                    return argMultimap.getAllValues(p).stream().anyMatch(String::isBlank);
                 });
 
         if (preamblePresent || nonePresent || anyPresentButInvalidEmpty) {

--- a/src/main/java/seedu/address/model/person/predicates/TagsMatchOneKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TagsMatchOneKeywordPredicate.java
@@ -52,9 +52,6 @@ public class TagsMatchOneKeywordPredicate implements Predicate<Person> {
                     boolean match = person.getTags().stream()
                             .anyMatch(tag -> {
                                 String tagString = tag.toString();
-                                if (tagString.length() <= 2) { // Account for empty tag
-                                    return false;
-                                }
                                 String trimmed = tagString.substring(1, tagString.length() - 1);
                                 return StringUtil.containsSubstringIgnoreCase(trimmed, subTag);
                             });

--- a/src/main/java/seedu/address/model/person/predicates/TagsMatchOneKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TagsMatchOneKeywordPredicate.java
@@ -40,26 +40,27 @@ public class TagsMatchOneKeywordPredicate implements Predicate<Person> {
             return false;
         }
 
-        // Tag prefix specified but empty, match only those with no tags
-        if (subTags.size() == 1 && subTags.get(0).isEmpty()) {
-            logger.info("Tag prefix specified without keywords.");
-            return person.getTags().isEmpty();
-        }
-
-        logger.fine("Tag prefix specified with keywords.");
+        logger.fine("Tag prefix specified");
         boolean result = subTags.stream()
                 .anyMatch(subTag -> {
+                    logger.fine("Processing blank tag prefix");
+                    if (subTag.isBlank()) {
+                        return person.getTags().isEmpty();
+                    }
+
+                    logger.fine("Processing normal tag prefix");
                     boolean match = person.getTags().stream()
                             .anyMatch(tag -> {
                                 String tagString = tag.toString();
                                 if (tagString.length() <= 2) { // Account for empty tag
-                                    return subTag.isEmpty();
+                                    return false;
                                 }
                                 String trimmed = tagString.substring(1, tagString.length() - 1);
                                 return StringUtil.containsSubstringIgnoreCase(trimmed, subTag);
                             });
                     logger.fine(MessageFormat.format(
                             "Checking keyword: {0}, match: {1}", subTag, match));
+
                     return match;
                 });
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -197,7 +197,7 @@ public class FindCommandParserTest {
         argMultimap = ArgumentTokenizer.tokenize(TEST_MULTIEMAIL1.toUpperCase(), PREFIX_EMAIL);
         expected = generateFindCommand();
 
-        assertParseDifferent(parser, MessageFormat.format("{0}{1}", PREFIX_EMAIL, TEST_MULTIEMAIL1), expected);
+        assertParseDifferent(parser, TEST_MULTIEMAIL1, expected);
     }
 
     @Test


### PR DESCRIPTION
Fix #250, Fix #252 , Fix #256, Fix #260, Fix #273