### PR TITLE
Update Documentation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1079,18 +1079,18 @@ Team size: 5
    emails, addresses, and tags, but it cannot search service notes or past log content. We plan to extend `find`
    with fields such as `--notes=...` and `--log=...` so users can locate clients using site instructions or previous
    job records.
-5. **Enhance phone number handling with country codes:** Linkline currently stores a single phone number per client with 
+5. **Enhance phone number handling with country codes**: Linkline currently stores a single phone number per client with 
    limited country code support. We plan to enhance this by allowing optional `+<country_code>` prefixes
    (e.g., `+65 91234567`) and normalizing numbers using `country_code + local_digits` for duplicate detection.
    This ensures `+65 9999 9999` and `9999 9999` are treated as duplicates, while `+66 9999 9999` remains distinct.
    We also plan to support a default country code (e.g., `setcountrycode 65`) so users can enter local numbers without
    typing `+65` every time.
-6. **Support multiple phone numbers per client:** Linkline currently stores only one phone number per client. We plan to
+6. **Support multiple phone numbers per client**: Linkline currently stores only one phone number per client. We plan to
    extend phone number storage to support multiple numbers (e.g., mobile, home, office). As an interim workaround, users
    can store secondary numbers in the `notes` field.
-7. **Improve duplicate error messages:** The current duplicate error message does not specify which field caused the
+7. **Improve duplicate error messages**: The current duplicate error message does not specify which field caused the
    duplicate or which client is affected. We plan to enhance it to show the duplicate field (phone or email), the name
    and index of the existing client, and a suggestion to use `list` if the duplicate is not visible in the current
    filtered view.
-8. **Repurpose the selection highlight:** The current highlight is a cosmetic leftover with no function. We plan to
+8. **Repurpose the selection highlight**: The current highlight is a cosmetic leftover with no function. We plan to
    repurpose it to provide useful feedback (e.g., indicating the most recently viewed client).

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -404,12 +404,12 @@ messages follow the same trimming rule as other parser-handled fields.
 | `Notes`      | Optional free text with max length 200 characters (`Notes#MAX_LENGTH`).                                                                      |
 | `LogMessage` | 1 to 1000 Unicode code points (`LogMessage#MIN_LENGTH`, `LogMessage#MAX_LENGTH`).                                                            |
 
+This keeps validation centralized and consistent for both command execution and JSON deserialization.
+
 These constraints are not perfect. For example, phone validation accepts unrealistic formats like `1 2 2-2` because
 it prioritizes flexibility (supporting international formats and readable spacing) over strictness. Country code support
 remains a planned enhancement. However, these constraints are sufficient for Linkline's target use case, and invalid
 entries can always be corrected later using the `edit` command.
-
-This keeps validation centralized and consistent for both command execution and JSON deserialization.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -46,7 +46,7 @@ Given below is a quick overview of main components and how they interact with ea
 
 **Main components of the architecture**
 
-**`Main`** (consisting of classes `Main` and `MainApp`) is in charge of the app launch and shut down.
+**`Main`** (consisting of classes `Main` and `MainApp`) is in charge of the app launch and shutdown.
 
 * At app launch, it initializes the other components in the correct sequence, and connects them up with each other.
 * At shutdown, it shuts down the other components and invokes cleanup methods where necessary.
@@ -1081,7 +1081,10 @@ Team size: 5
    This ensures `+65 9999 9999` and `9999 9999` are treated as duplicates, while `+66 9999 9999` remains distinct.
    We also plan to support a default country code (e.g., `setcountrycode 65`) so users can enter local numbers without
    typing `+65` every time.
-
 6. **Support multiple phone numbers per client:** Linkline currently stores only one phone number per client. We plan to
    extend phone number storage to support multiple numbers (e.g., mobile, home, office). As an interim workaround, users
    can store secondary numbers in the `notes` field.
+7. **Improve duplicate error messages:** The current duplicate error message does not specify which field caused the
+   duplicate or which client is affected. We plan to enhance it to show the duplicate field (phone or email), the name
+   and index of the existing client, and a suggestion to use `list` if the duplicate is not visible in the current
+   filtered view.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -135,8 +135,8 @@ The sequence diagram below illustrates the interactions within the `Logic` compo
 
 <box type="info" seamless>
 
-**Note:** The lifeline for `DeleteCommandParser` should end at the destroy marker (X) but due to a limitation of
-PlantUML, the lifeline continues till the end of diagram.
+**Note:** The lifeline for `DeleteCommandParser`, `DeleteCommand` and `CommandResult` should end at the destroy marker
+(X) but due to a limitation of PlantUML, the lifeline continues till the end of diagram.
 </box>
 
 How the `Logic` component works:

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1092,3 +1092,5 @@ Team size: 5
    duplicate or which client is affected. We plan to enhance it to show the duplicate field (phone or email), the name
    and index of the existing client, and a suggestion to use `list` if the duplicate is not visible in the current
    filtered view.
+8. **Repurpose the selection highlight:** The current highlight is a cosmetic leftover with no function. We plan to
+   repurpose it to provide useful feedback (e.g., indicating the most recently viewed client).

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1037,8 +1037,6 @@ Removing or renaming optional fields such as `notes`, `logs`, or `tags` may stil
 ## **Appendix: Effort**
 This project extends the AddressBook-Level 3 (AB3) codebase into Linkline, a client management system tailored for solo service technicians. While AB3 serves as a simple contact manager, Linkline introduces domain-specific features such as service logs, confirmation flows and corrupted file handling.
 
-<box type="info" seamless>
-
 ### Challenges
 
 | **Challenge** | **Description**                                                                                                                                                               |
@@ -1050,8 +1048,6 @@ This project extends the AddressBook-Level 3 (AB3) codebase into Linkline, a cli
 | **Duplicate detection** | Enhanced `edit` command to prevent duplicate phone/email across different clients while allowing self-edits.                                                                  |
 | **Corrupted file handling** | Added detection and user-friendly error messaging for corrupted `linkline.json` without auto-overwriting.                                                                     |
 | **UI improvements** | Redesigned the interface with a split-pane layout featuring a compact list view (showing name and phone) and a full details panel (showing all client information when selected via `view`).                                                                                                         |
-
-</box>
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -406,7 +406,11 @@ messages follow the same trimming rule as other parser-handled fields.
 
 This keeps validation centralized and consistent for both command execution and JSON deserialization.
 
-These constraints are not perfect. For example, phone validation accepts unrealistic formats like `1 2 2-2` because
+These constraints are not perfect. For example:
+* **Name validation** uses a 1-100 character limit. The minimum prevents blank names, while the maximum accommodates
+real-world names (most are under 50 characters). The limit is measured in Unicode code points to support multi-language
+names.
+* **Phone validation** accepts unrealistic formats like `1 2 2-2` because
 it prioritizes flexibility (supporting international formats and readable spacing) over strictness. Country code support
 remains a planned enhancement. However, these constraints are sufficient for Linkline's target use case, and invalid
 entries can always be corrected later using the `edit` command.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -404,6 +404,11 @@ messages follow the same trimming rule as other parser-handled fields.
 | `Notes`      | Optional free text with max length 200 characters (`Notes#MAX_LENGTH`).                                                                      |
 | `LogMessage` | 1 to 1000 Unicode code points (`LogMessage#MIN_LENGTH`, `LogMessage#MAX_LENGTH`).                                                            |
 
+These constraints are not perfect. For example, phone validation accepts unrealistic formats like `1 2 2-2` because
+it prioritizes flexibility (supporting international formats and readable spacing) over strictness. Country code support
+remains a planned enhancement. However, these constraints are sufficient for Linkline's target use case, and invalid
+entries can always be corrected later using the `edit` command.
+
 This keeps validation centralized and consistent for both command execution and JSON deserialization.
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -635,9 +635,6 @@ previous Linkline home folder.
    primary screen, the GUI may open off-screen. Delete `preferences.json` before starting Linkline again.
 2. **If you minimize the Help Window** and then run `help` again, the original Help Window remains minimized and no new
    Help Window appears. Restore the minimized Help Window manually.
-3. **Duplicate error messages are not field-specific**. The error message does not tell users whether the duplicate was
-   caused by a matching phone number or email address. Users need to manually check existing clients to identify the
-   duplicate.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -194,7 +194,7 @@ edit INDEX [--name=NAME] [--phone=PHONE_NUMBER] [--email=EMAIL] [--address=ADDRE
 * Any field you provide replaces the client's current value for that field.
 * Editing tags is not cumulative. If you provide `--tag=`, Linkline replaces the client's entire tag list with the tags
   you supplied.
-* Use `--tag=` with no value to clear all tags.
+* Use `--tag=` with no value to clear all tags (cannot be combined with other `--tag=` fields in the same command).
 * Use `--notes=` with no value to clear notes.
 * Linkline rejects edits that would make the client duplicate another existing client.
 
@@ -222,6 +222,13 @@ delete INDEX
 * Any other command, including an invalid command, provided after the first `delete` command cancels the pending
   deletion.
 
+<box type="tip" seamless>
+
+**Tip:** After the first `delete 1`, commands such as `delete 1` and `delete 01` both confirm the deletion because
+Linkline compares the parsed index value. Leading/trailing spaces and spaces between the command word and index are
+ignored. Numbers with leading zeros (e.g., '01', '001') also confirm the deletion.
+</box>
+
 Examples:
 
 * `delete 1` followed by `find --name=Bernice`
@@ -234,13 +241,6 @@ Example result after a `delete` command (with confirmation):
 ![pending delete command result](images/pendingDeleteCommandResult.png)
 
 ![confirmed delete command result](images/confirmedDeleteCommandResult.png)
-
-<box type="tip" seamless>
-
-**Tip:** After the first `delete 1`, commands such as `delete 1` and `delete 01` both confirm the deletion because
-Linkline compares the parsed index value. Leading/trailing spaces and spaces between the command word and index are
-ignored. Numbers with leading zeros (e.g., '01', '001') also confirm the deletion.
-</box>
 
 ### Clearing all entries: `clear`
 
@@ -310,7 +310,7 @@ Searches the currently displayed list for clients whose name, phone number, emai
 matches at least one supplied query. Uses `OR` matching across all supplied queries and fields.
 
 `find` will only search based on the clients currently in the displayed list. \
-Both `find` and `filtertag` commands can be used to narrow down the current list. \
+Both `find` and `filtertag` commands can be used to narrow down the current list.
 
 Use `list` when you want to search from the full client list again.
 
@@ -407,10 +407,10 @@ Examples:
 
 <box type="warning" seamless>
 
-**Warning:** The `copyaddr` command copies the address based on the current displayed index. The copied address may
+**Warning:** The `copyaddr` command copies the address based on the current **displayed index**. The copied address may
 become outdated if:
 
-- The client list changes (e.g., via `list` or `find`), causing the index to point to a different client.
+- The client list changes (e.g., using `list` or `find`), causing the index to point to a different client.
 - The client's address is edited after copying.
   </box>
 
@@ -431,6 +431,7 @@ copyedit INDEX
 * If the client has notes, the copied command also includes `--notes=...`.
 * This is useful when you want to change a field with long or multiple values (e.g., tags, notes, ...) without retyping
   the rest.
+* If Linkline cannot access the clipboard, it shows an error instead of copying anything.
 
 Examples:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -627,8 +627,6 @@ previous Linkline home folder.
    primary screen, the GUI may open off-screen. Delete `preferences.json` before starting Linkline again.
 2. **If you minimize the Help Window** and then run `help` again, the original Help Window remains minimized and no new
    Help Window appears. Restore the minimized Help Window manually.
-3. **Phone number validation is flexible by design.** It only checks total digit count (3-15) and allows spaces and
-    hyphens between digits for readability. Formats like `1 2-2-2` are accepted because they meet the basic criteria.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -627,6 +627,8 @@ previous Linkline home folder.
    primary screen, the GUI may open off-screen. Delete `preferences.json` before starting Linkline again.
 2. **If you minimize the Help Window** and then run `help` again, the original Help Window remains minimized and no new
    Help Window appears. Restore the minimized Help Window manually.
+3. **Phone number validation is flexible by design.** It only checks total digit count (3-15) and allows spaces and
+    hyphens between digits for readability. Formats like `1 2-2-2` are accepted because they meet the basic criteria.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -194,7 +194,8 @@ edit INDEX [--name=NAME] [--phone=PHONE_NUMBER] [--email=EMAIL] [--address=ADDRE
 * Any field you provide replaces the client's current value for that field.
 * Editing tags is not cumulative. If you provide `--tag=`, Linkline replaces the client's entire tag list with the tags
   you supplied.
-* Use `--tag=` with no value to clear all tags (cannot be combined with other `--tag=` fields in the same command).
+* Use `--tag=` with no value to clear all tags. In this case, it cannot be combined with other `--tag=` fields in the
+  same command.
 * Use `--notes=` with no value to clear notes.
 * Linkline rejects edits that would make the client duplicate another existing client.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -202,8 +202,8 @@ edit INDEX [--name=NAME] [--phone=PHONE_NUMBER] [--email=EMAIL] [--address=ADDRE
 <box type="tip" seamless>
 
 **Note on editing clients on filtered lists:** If you edit a client while viewing a filtered list (e.g., after using
-`find` or `filtertag`), the client may disappear from the displayed list if the edited details no longer match the
-current filter criteria. Use `list` to see all clients again.
+`find` or `filtertag`), the client may disappear from the displayed client list and details panel if the edited details
+no longer match the current filter criteria. Use `list` to see all clients again.
 </box>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,8 +151,8 @@ add --name=NAME --phone=PHONE_NUMBER --email=EMAIL --address=ADDRESS [--notes=NO
 
 * `--name=`, `--phone=`, `--email=`, and `--address=` are required.
 * `--tag=` can be repeated. Other named fields can appear at most once.
-* Linkline rejects duplicates. Two clients are considered duplicates if they share the same email address (
-  case-insensitive) or the same phone number after ignoring spaces and hyphens.
+* Linkline rejects duplicates. Two clients are considered duplicates if they share the same email address
+(case-insensitive) or the same phone number after ignoring spaces and hyphens.
 * After a successful `add`, Linkline shows the full client list again.
 
 <box type="tip" seamless>
@@ -245,7 +245,7 @@ Examples:
   * Shows confirmation message for deleting the client at index 1.
   * If you enter `delete 1` again, the client at index 1 is deleted.
 
-Example result after a `delete` command (with confirmation):
+Example result of `delete` command with confirmation (first attempt and confirmed deletion):
 ![pending delete command result](images/pendingDeleteCommandResult.png)
 
 ![confirmed delete command result](images/confirmedDeleteCommandResult.png)
@@ -266,7 +266,7 @@ clear
     * The second `clear` clears all entries.
 * Any other command, including an invalid command, provided after the first `clear` command cancels the pending action.
 
-Example result after a `clear` command with a successful confirmation:
+Example result after confirming `clear`:
 ![clear command result](images/clearCommandResult.png)
 
 ### Listing all clients: `list`
@@ -517,7 +517,7 @@ Examples:
     * Shows confirmation message for deleting log `1` of client `3`.
     * If you enter `logdelete 3 1` again, the corresponding log is deleted.
 
-Example result after a `logdelete` command:
+Example result after confirming `logdelete`:
 ![confirmed logdelete command result](images/logdeleteCommandResult.png)
 
 ### Renaming a tag: `renametag`
@@ -570,7 +570,7 @@ Examples:
     * Shows confirmation message for deleting tag `ac-repair`.
     * If you enter `deletetag ac-repair` again, the tag `ac-repair` is deleted.
 
-Example result after a `deletetag` command:
+Example result after confirming `deletetag`:
 ![confirmed deletetag command result](images/deletetagCommandResult.png)
 
 ### Exiting Linkline: `exit`
@@ -635,6 +635,9 @@ previous Linkline home folder.
    primary screen, the GUI may open off-screen. Delete `preferences.json` before starting Linkline again.
 2. **If you minimize the Help Window** and then run `help` again, the original Help Window remains minimized and no new
    Help Window appears. Restore the minimized Help Window manually.
+3. **Duplicate error messages are not field-specific**. The error message does not tell users whether the duplicate was
+   caused by a matching phone number or email address. Users need to manually check existing clients to identify the
+   duplicate.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -198,6 +198,13 @@ edit INDEX [--name=NAME] [--phone=PHONE_NUMBER] [--email=EMAIL] [--address=ADDRE
 * Use `--notes=` with no value to clear notes.
 * Linkline rejects edits that would make the client duplicate another existing client.
 
+<box type="tip" seamless>
+
+**Note on editing clients on filtered lists:** If you edit a client while viewing a filtered list (e.g., after using
+`find` or `filtertag`), the client may disappear from the displayed list if the edited details no longer match the
+current filter criteria. Use `list` to see all clients again.
+</box>
+
 Examples:
 
 * `edit 1 --phone=91234567 --email=johndoe@example.com`

--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -53,12 +53,12 @@ activate DeleteCommand
 
 DeleteCommand -> Model : getFilteredPersonList()
 activate Model
-Model --> DeleteCommand : personList
+Model --> DeleteCommand : lastShownList
 deactivate Model
 
 note right of DeleteCommand
 Reads the target client
-from the returned list
+from lastShownList
 end note
 
 create DeletePendingAction
@@ -76,6 +76,7 @@ deactivate CommandResult
 
 DeleteCommand --> LogicManager : result
 deactivate DeleteCommand
+destroy DeleteCommand
 
 LogicManager -> CommandResult : hasPendingAction()
 activate CommandResult
@@ -86,6 +87,7 @@ LogicManager -> CommandResult : getPendingAction()
 activate CommandResult
 CommandResult --> LogicManager : pendingAction
 deactivate CommandResult
+destroy CommandResult
 
 note right of LogicManager : store pendingAction
 

--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -54,8 +54,6 @@ HelpWindow --|> UiPart
 PersonDetailPanel --|> UiPart
 
 PersonCard ..> Model
-PersonListPanel ..> Model
-PersonDetailPanel ..> Model
 PersonDetailCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -20,7 +20,7 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Linkline has been cleared!";
     public static final String MESSAGE_CLEAR_CONFIRM =
             "Are you sure you want to clear all entries from Linkline?\n"
-                    + "Type 'clear' again to confirm."
+                    + "Type 'clear' again to confirm. "
                     + "(Any leading/trailing spaces will be trimmed)\n"
                     + "Any other command will cancel this pending action.";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -55,7 +55,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Client: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON =  "A client with the same phone number (ignoring formatting)"
+    public static final String MESSAGE_DUPLICATE_PERSON = "A client with the same phone number (ignoring formatting)"
             + " or email already exists";
     private static final Logger logger = LogsCenter.getLogger(EditCommand.class);
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -55,7 +55,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Client: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This client already exists in Linkline.";
+    public static final String MESSAGE_DUPLICATE_PERSON =  "A client with the same phone number (ignoring formatting)"
+            + " or email already exists";
     private static final Logger logger = LogsCenter.getLogger(EditCommand.class);
 
     private final Index index;


### PR DESCRIPTION
Fixes #308 

There was an additional backslash in the documentation so I removed it too:
<img width="1092" height="156" alt="image" src="https://github.com/user-attachments/assets/06e9c8f8-b895-4bed-890d-5bb8c7785ba7" />